### PR TITLE
ci: use reusable workflows from pyTooling/Actions

### DIFF
--- a/.btd.yml
+++ b/.btd.yml
@@ -4,6 +4,6 @@ requirements: requirements.txt
 target: gh-pages
 formats: [ html, pdf, man ]
 images:
-  base: edaa/doc
+  base: btdi/sphinx:pytooling
   latex: btdi/latex
 theme: https://codeload.GitHub.com/buildthedocs/sphinx.theme/tar.gz/v1

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -13,7 +13,10 @@ jobs:
 
   UnitTesting:
     uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@dev
+    needs:
+      - Params
     with:
+      jobs: ${{ needs.Params.outputs.python_jobs }}
       TestReport: true
 
   Coverage:

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -4,11 +4,8 @@ on:
   push:
   workflow_dispatch:
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
+
   UnitTesting:
     name: ${{ matrix.icon }} Unit Tests using Python ${{ matrix.python }}
     runs-on: ubuntu-latest

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -29,22 +29,22 @@ jobs:
     secrets:
       codacy_token: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
-  Release:
-    uses: pyTooling/Actions/.github/workflows/Release.yml@dev
-    if: startsWith(github.ref, 'refs/tags')
-    needs:
-      - UnitTesting
-      - Coverage
-
   Package:
     uses: pyTooling/Actions/.github/workflows/Package.yml@dev
-    if: startsWith(github.ref, 'refs/tags')
     needs:
       - Params
       - Coverage
     with:
       python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
+
+  Release:
+    uses: pyTooling/Actions/.github/workflows/Release.yml@dev
+    if: startsWith(github.ref, 'refs/tags')
+    needs:
+      - UnitTesting
+      - Coverage
+      - Package
 
   PublishOnPyPI:
     uses: pyTooling/Actions/.github/workflows/PublishOnPyPI.yml@dev

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -12,57 +12,9 @@ jobs:
       name: pySVModel
 
   UnitTesting:
-    name: ${{ matrix.icon }} Unit Tests using Python ${{ matrix.python }}
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - {python: "3.6",  icon: 🔴}  # until 23.12.2021
-          - {python: "3.7",  icon: 🟠}  # until 27.06.2023
-          - {python: "3.8",  icon: 🟡}  # until Oct. 2024
-          - {python: "3.9",  icon: 🟢}  # until Oct. 2025
-          - {python: "3.10", icon: 🟢}  # until Oct. 2026
-
-    env:
-      PYTHON: ${{ matrix.python }}
-    outputs:
-      python: ${{ env.PYTHON }}
-
-    steps:
-      - name: ⏬ Checkout repository
-        uses: actions/checkout@v2
-
-      - name: 🐍 Setup Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python }}
-
-      - name: 🔧 Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r tests/requirements.txt
-
-      - name: ☑ Run unit tests
-        run: |
-          python -m pytest -rA --junitxml=TestReport.xml tests/unit
-
-      - name: 📤 Upload 'TestReport.xml' artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: TestReport-${{ env.PYTHON }}
-          path: TestReport.xml
-          if-no-files-found: error
-          retention-days: 1
-
-      - name: 📊 Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
-        if: always()
-        with:
-          files: TestReport.xml
-          comment_title: Unit Test Results (Python ${{ env.PYTHON }})
-
+    uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@dev
+    with:
+      TestReport: true
 
   Coverage:
     name: 📈 Collect Coverage Data using Python 3.10

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -17,52 +17,14 @@ jobs:
       TestReport: true
 
   Coverage:
-    name: 📈 Collect Coverage Data using Python 3.10
-    runs-on: ubuntu-latest
-
-    env:
-      PYTHON: "3.10"
-    outputs:
-      python: ${{ env.PYTHON }}
-
-    steps:
-      - name: ⏬ Checkout repository
-        uses: actions/checkout@v2
-
-      - name: 🐍 Setup Python ${{ env.PYTHON }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.PYTHON }}
-
-      - name: 🗂 Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r tests/requirements.txt
-
-      - name: Collect coverage
-        continue-on-error: true
-        run: |
-          python -m pytest -rA --cov=.. --cov-config=tests/.coveragerc tests/unit
-
-      - name: Convert to cobertura format
-        run: |
-          coverage xml
-
-      - name: 📊 Publish coverage at CodeCov
-        continue-on-error: true
-        uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage.xml
-          flags: unittests
-          env_vars: PYTHON
-
-      - name: 📉 Publish coverage at Codacy
-        continue-on-error: true
-        uses: codacy/codacy-coverage-reporter-action@master
-        with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: ./coverage.xml
-
+    uses: pyTooling/Actions/.github/workflows/CoverageCollection.yml@dev
+    needs:
+      - Params
+    with:
+      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
+      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
+    secrets:
+      codacy_token: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
   Release:
     name: 📝 Create 'Release Page' on GitHub

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -21,7 +21,7 @@ jobs:
     needs:
       - Params
     with:
-      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
+      python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
     secrets:
       codacy_token: ${{ secrets.CODACY_PROJECT_TOKEN }}
@@ -40,7 +40,7 @@ jobs:
       - Params
       - Coverage
     with:
-      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
+      python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.wheel }}
 
   PublishOnPyPI:
@@ -51,7 +51,7 @@ jobs:
       - Release
       - Package
     with:
-      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
+      python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.wheel }}
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -56,87 +56,22 @@ jobs:
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
-#  VerifyDocs:
-#    name: 👍 Verify example snippets using Python 3.10
-#    runs-on: ubuntu-latest
-#
-#    env:
-#      PYTHON: "3.10"
-#    outputs:
-#      python: ${{ env.PYTHON }}
-#
-#    steps:
-#      - name: ⏬ Checkout repository
-#        uses: actions/checkout@v2
-#
-#      - name: ⚙ Setup GHDL
-#        uses: ghdl/setup-ghdl-ci@master
-#
-#      - name: 🐍 Setup Python
-#        uses: actions/setup-python@v2
-#        with:
-#          python-version: ${{ env.PYTHON }}
-#
-#      - name: 🐍 Install dependencies
-#        run: |
-#          pip3 install git+https://GitHub.com/ghdl/ghdl.git@$(ghdl version hash)
-#
-#      - name: ✂ Extract code snippet from README
-#        shell: python
-#        run: |
-#          from pathlib import Path
-#          import re
-#
-#          ROOT = Path('.')
-#
-#          with (ROOT / 'README.md').open('r') as rptr:
-#              content = rptr.read()
-#
-#          m = re.search(r"```py(thon)?(?P<code>.*?)```", content, re.MULTILINE|re.DOTALL)
-#
-#          if m is None:
-#              raise Exception("Regular expression did not find the example in the README!")
-#
-#          with (ROOT / 'tests/docs/example.py').open('w') as wptr:
-#              wptr.write(m["code"])
-#
-##      - name: Print example.py
-##        run: cat tests/docs/example.py
-#
-#      - name: ☑ Run example snippet
-#        working-directory: tests/docs
-#        run: |
-#          python3 example.py
-
-
   BuildTheDocs:
-    name: 📓 Run BuildTheDocs and publish to GH-Pages
-    runs-on: ubuntu-latest
+    uses: pyTooling/Actions/.github/workflows/BuildTheDocs.yml@dev
+    needs:
+      - Params
+    with:
+      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}
 
-#    needs:
-#      - VerifyDocs
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: 🚢 Build container image 'EDAA/doc'
-        run: |
-          docker build -t edaa/doc - <<-EOF
-          FROM btdi/sphinx:featured
-          RUN apk add -U --no-cache graphviz
-          EOF
-
-      - name: 🛳️ Build documentation using container edaa/doc and publish to GitHub Pages
-        uses: buildthedocs/btd@v0
-        with:
-          token: ${{ github.token }}
-
-      - name: 📤 Upload artifacts
-        uses: actions/upload-artifact@master
-        with:
-          name: doc
-          path: doc/_build/html
+  PublishToGitHubPages:
+    uses: pyTooling/Actions/.github/workflows/PublishToGitHubPages.yml@dev
+    needs:
+      - Params
+      - BuildTheDocs
+      - Coverage
+    with:
+      doc: ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}
+      coverage: ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
 
 
   ArtifactCleanUp:

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -44,44 +44,17 @@ jobs:
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.wheel }}
 
   PublishOnPyPI:
-    name: 🚀 Publish to PyPI
-    runs-on: ubuntu-latest
-
+    uses: pyTooling/Actions/.github/workflows/PublishOnPyPI.yml@dev
     if: startsWith(github.ref, 'refs/tags')
     needs:
+      - Params
+      - Release
       - Package
-
-    env:
-      PYTHON:   ${{ needs.Package.outputs.python }}
-      ARTIFACT: ${{ needs.Package.outputs.artifact }}
-    outputs:
-      python:   ${{ env.PYTHON }}
-      artifact: ${{ env.ARTIFACT }}
-
-    steps:
-      - name: 📥 Download artifacts '${{ env.ARTIFACT }}' from 'Package' job
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ env.ARTIFACT }}
-          path: dist/
-
-      - name: 🐍 Setup Python ${{ env.PYTHON }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.PYTHON }}
-
-      - name: ⚙ Install dependencies for packaging and release
-        run: |
-          python -m pip install --upgrade pip
-          pip install wheel twine
-
-      - name: ⤴ Release Python package to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          twine upload dist/*
-
+    with:
+      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
+      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.wheel }}
+    secrets:
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
 #  VerifyDocs:
 #    name: 👍 Verify example snippets using Python 3.10

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -17,7 +17,7 @@ jobs:
       - Params
     with:
       jobs: ${{ needs.Params.outputs.python_jobs }}
-      TestReport: true
+      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}
 
   Coverage:
     uses: pyTooling/Actions/.github/workflows/CoverageCollection.yml@dev
@@ -44,7 +44,7 @@ jobs:
       - Coverage
     with:
       python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
-      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.wheel }}
+      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
 
   PublishOnPyPI:
     uses: pyTooling/Actions/.github/workflows/PublishOnPyPI.yml@dev
@@ -55,7 +55,7 @@ jobs:
       - Package
     with:
       python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
-      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.wheel }}
+      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
@@ -87,9 +87,18 @@ jobs:
       - PublishToGitHubPages
 
     steps:
+
+      - name: ðŸ—‘ï¸ Delete package Artifacts
+        if: ${{ ! startsWith(github.ref, 'refs/tags') }}
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: |
+            ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
+
       - name: 🗑️ Delete all Artifacts
         uses: geekyeggo/delete-artifact@v1
         with:
           name: |
+            ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-*
             ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
             ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -77,17 +77,16 @@ jobs:
   ArtifactCleanUp:
     name: 🗑️ Artifact Cleanup
     runs-on: ubuntu-latest
-
     needs:
-      - Package
-      - PublishOnPyPI
-
-    env:
-      ARTIFACT: ${{ needs.Package.outputs.artifact }}
+      - Params
+      - Coverage
+      - BuildTheDocs
+      - PublishToGitHubPages
 
     steps:
       - name: 🗑️ Delete all Artifacts
         uses: geekyeggo/delete-artifact@v1
         with:
           name: |
-            ${{ env.ARTIFACT }}
+            ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
+            ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -27,57 +27,11 @@ jobs:
       codacy_token: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
   Release:
-    name: 📝 Create 'Release Page' on GitHub
-    runs-on: ubuntu-latest
-
+    uses: pyTooling/Actions/.github/workflows/Release.yml@dev
     if: startsWith(github.ref, 'refs/tags')
     needs:
       - UnitTesting
       - Coverage
-
-    env:
-      PYTHON: ${{ needs.Coverage.outputs.python }}
-    outputs:
-      python:     ${{ env.PYTHON }}
-      tag:        ${{ steps.getVariables.outputs.gitTag }}
-      version:    ${{ steps.getVariables.outputs.version }}
-      datetime:   ${{ steps.getVariables.outputs.datetime }}
-      upload_url: ${{ steps.createReleasePage.outputs.upload_url }}
-
-    steps:
-      - name: 🔁 Extract Git tag from GITHUB_REF
-        id:   getVariables
-        run: |
-          GIT_TAG=${GITHUB_REF#refs/*/}
-          RELEASE_VERSION=${GIT_TAG#v}
-          RELEASE_DATETIME="$(date --utc '+%d.%m.%Y - %H:%M:%S')"
-          # write to step outputs
-          echo ::set-output name=gitTag::${GIT_TAG}
-          echo ::set-output name=version::${RELEASE_VERSION}
-          echo ::set-output name=datetime::${RELEASE_DATETIME}
-
-      - name: 📑 Create Release Page
-        id:   createReleasePage
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.getVariables.outputs.gitTag }}
-#          release_name: ${{ steps.getVariables.outputs.gitTag }}
-          body: |
-            **Automated Release created on: ${{ steps.getVariables.outputs.datetime }}**
-
-            # New Features
-            * tbd
-
-            # Changes
-            * tbd
-
-            # Bug Fixes
-            * tbd
-          draft: false
-          prerelease: false
-
 
   Package:
     name: 📦 Package in Wheel Format

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -34,50 +34,14 @@ jobs:
       - Coverage
 
   Package:
-    name: 📦 Package in Wheel Format
-    runs-on: ubuntu-latest
-
+    uses: pyTooling/Actions/.github/workflows/Package.yml@dev
     if: startsWith(github.ref, 'refs/tags')
     needs:
+      - Params
       - Coverage
-
-    env:
-      PYTHON:   ${{ needs.Coverage.outputs.python }}
-      ARTIFACT: pySVModel-wheel
-    outputs:
-      python:   ${{ env.PYTHON }}
-      artifact: ${{ env.ARTIFACT }}
-
-    steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v2
-
-      - name: 🐍 Setup Python ${{ env.PYTHON }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.PYTHON }}
-
-      - name: 🔧 Install dependencies for packaging and release
-        run: |
-          python -m pip install --upgrade pip
-          pip install wheel
-
-      - name: 🔨 Build Python package (source distribution)
-        run: |
-          python setup.py sdist
-
-      - name: 🔨 Build Python package (binary distribution - wheel)
-        run: |
-          python setup.py bdist_wheel
-
-      - name: 📤 Upload 'pySVModel' artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.ARTIFACT }}
-          path: dist/
-          if-no-files-found: error
-          retention-days: 1
-
+    with:
+      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
+      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.wheel }}
 
   PublishOnPyPI:
     name: 🚀 Publish to PyPI

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -76,29 +76,17 @@ jobs:
       doc: ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}
       coverage: ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
 
-
   ArtifactCleanUp:
-    name: 🗑️ Artifact Cleanup
-    runs-on: ubuntu-latest
+    uses: pyTooling/Actions/.github/workflows/ArtifactCleanUp.yml@dev
     needs:
       - Params
+      - UnitTesting
       - Coverage
       - BuildTheDocs
       - PublishToGitHubPages
-
-    steps:
-
-      - name: ðŸ—‘ï¸ Delete package Artifacts
-        if: ${{ ! startsWith(github.ref, 'refs/tags') }}
-        uses: geekyeggo/delete-artifact@v1
-        with:
-          name: |
-            ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
-
-      - name: 🗑️ Delete all Artifacts
-        uses: geekyeggo/delete-artifact@v1
-        with:
-          name: |
-            ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-*
-            ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
-            ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}
+    with:
+      package: ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
+      remaining: |
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-*
+        ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
+        ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -7,12 +7,12 @@ on:
 jobs:
 
   Params:
-    uses: pyTooling/Actions/.github/workflows/Params.yml@dev
+    uses: pyTooling/Actions/.github/workflows/Params.yml@r0
     with:
       name: pySVModel
 
   UnitTesting:
-    uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@dev
+    uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@r0
     needs:
       - Params
     with:
@@ -20,7 +20,7 @@ jobs:
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}
 
   Coverage:
-    uses: pyTooling/Actions/.github/workflows/CoverageCollection.yml@dev
+    uses: pyTooling/Actions/.github/workflows/CoverageCollection.yml@r0
     needs:
       - Params
     with:
@@ -30,7 +30,7 @@ jobs:
       codacy_token: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
   Package:
-    uses: pyTooling/Actions/.github/workflows/Package.yml@dev
+    uses: pyTooling/Actions/.github/workflows/Package.yml@r0
     needs:
       - Params
       - Coverage
@@ -39,7 +39,7 @@ jobs:
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
 
   Release:
-    uses: pyTooling/Actions/.github/workflows/Release.yml@dev
+    uses: pyTooling/Actions/.github/workflows/Release.yml@r0
     if: startsWith(github.ref, 'refs/tags')
     needs:
       - UnitTesting
@@ -47,7 +47,7 @@ jobs:
       - Package
 
   PublishOnPyPI:
-    uses: pyTooling/Actions/.github/workflows/PublishOnPyPI.yml@dev
+    uses: pyTooling/Actions/.github/workflows/PublishOnPyPI.yml@r0
     if: startsWith(github.ref, 'refs/tags')
     needs:
       - Params
@@ -60,14 +60,14 @@ jobs:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
   BuildTheDocs:
-    uses: pyTooling/Actions/.github/workflows/BuildTheDocs.yml@dev
+    uses: pyTooling/Actions/.github/workflows/BuildTheDocs.yml@r0
     needs:
       - Params
     with:
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}
 
   PublishToGitHubPages:
-    uses: pyTooling/Actions/.github/workflows/PublishToGitHubPages.yml@dev
+    uses: pyTooling/Actions/.github/workflows/PublishToGitHubPages.yml@r0
     needs:
       - Params
       - BuildTheDocs
@@ -77,7 +77,7 @@ jobs:
       coverage: ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
 
   ArtifactCleanUp:
-    uses: pyTooling/Actions/.github/workflows/ArtifactCleanUp.yml@dev
+    uses: pyTooling/Actions/.github/workflows/ArtifactCleanUp.yml@r0
     needs:
       - Params
       - UnitTesting

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -6,6 +6,11 @@ on:
 
 jobs:
 
+  Params:
+    uses: pyTooling/Actions/.github/workflows/Params.yml@dev
+    with:
+      name: pySVModel
+
   UnitTesting:
     name: ${{ matrix.icon }} Unit Tests using Python ${{ matrix.python }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
In this PR, the CI Pipeline is reworked in order to use reusable workflows from pyTooling/Actions (see pyTooling/Actions#1).

Each job is replaced with a call to a reusable workflow.

As explained in VHDL/pyVHDLModel#36, the logic for dealing with global parameters is changed.

MPORTANT: reusable workflows must be used through an absolute name and specifying a version (see actions/runner#1493). Therefore, this PR will be kept as a draft, because s/@dev/@main/ is required in Pipeline.yml before merging.