### PR TITLE
requirements: bump pyTooling to v1.5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyTooling>=1.4.4
+pyTooling>=1.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyTooling>=1.5.0
+pyTooling>=1.5.1


### PR DESCRIPTION
In order to fix the packaging issues with v1.4.4 and v1.5.0.