### PR TITLE
ci/Pipeline: change name to just 'Pipeline'; update refs accordingly

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -1,4 +1,4 @@
-name: Unit Testing, Coverage Collection, Package, Release, Documentation and Publish
+name: Pipeline
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![PyPI](https://img.shields.io/pypi/v/pySVModel?longCache=true&style=flat-square&logo=PyPI&logoColor=FBE072)](https://pypi.org/project/pySVModel/)
 ![PyPI - Status](https://img.shields.io/pypi/status/pySVModel?longCache=true&style=flat-square&logo=PyPI&logoColor=FBE072)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pySVModel?longCache=true&style=flat-square&logo=PyPI&logoColor=FBE072)  
-[![GitHub Workflow - Build and Test Status](https://img.shields.io/github/workflow/status/edaa-org/pySVModel/Unit%20Testing,%20Coverage%20Collection,%20Package,%20Release,%20Documentation%20and%20Publish/main?longCache=true&style=flat-square&label=Build%20and%20Test&logo=GitHub%20Actions&logoColor=FFFFFF)](https://GitHub.com/edaa-org/pySVModel/actions?query=workflow%3A%22Pipeline%22)
+[![GitHub Workflow - Build and Test Status](https://img.shields.io/github/workflow/status/edaa-org/pySVModel/Pipeline/main?longCache=true&style=flat-square&label=Build%20and%20Test&logo=GitHub%20Actions&logoColor=FFFFFF)](https://GitHub.com/edaa-org/pySVModel/actions/workflows/Pipeline.yml)
 [![Libraries.io status for latest release](https://img.shields.io/librariesio/release/pypi/pySVModel?longCache=true&style=flat-square&logo=Libraries.io&logoColor=fff)](https://libraries.io/github/edaa-org/pySVModel)
 [![Codacy - Quality](https://img.shields.io/codacy/grade/39d312bf98244961975559f141c3e000?longCache=true&style=flat-square&logo=Codacy)](https://app.codacy.com/gh/edaa-org/pySVModel)
 [![Codacy - Coverage](https://img.shields.io/codacy/coverage/39d312bf98244961975559f141c3e000?longCache=true&style=flat-square&logo=Codacy)](https://app.codacy.com/gh/edaa-org/pySVModel)

--- a/doc/shields.inc
+++ b/doc/shields.inc
@@ -64,14 +64,14 @@
    :target: https://GitHub.com/edaa-org/pySVModel/network/dependents
 
 .. # GHA test and coverage
-.. |SHIELD:svg:pySVModel-gha-test| image:: https://img.shields.io/github/workflow/status/edaa-org/pySVModel/Unit%20Testing,%20Coverage%20Collection,%20Package,%20Release,%20Documentation%20and%20Publish/main?longCache=true&style=flat-square&label=Build%20and%20Test&logo=GitHub%20Actions&logoColor=FFFFFF
+.. |SHIELD:svg:pySVModel-gha-test| image:: https://img.shields.io/github/workflow/status/edaa-org/pySVModel/Pipeline/main?longCache=true&style=flat-square&label=Build%20and%20Test&logo=GitHub%20Actions&logoColor=FFFFFF
    :alt: GitHub Workflow - Build and Test Status
    :height: 22
-   :target: https://GitHub.com/edaa-org/pySVModel/actions?query=workflow%3A%22Test+and+Coverage%22
-.. |SHIELD:png:pySVModel-gha-test| image:: https://img.shields.io/github/workflow/status/edaa-org/pySVModel/Unit%20Testing,%20Coverage%20Collection,%20Package,%20Release,%20Documentation%20and%20Publish/main?longCache=true&style=flat-square&label=Build%20and%20Test&logo=GitHub%20Actions&logoColor=FFFFFF
+   :target: https://GitHub.com/edaa-org/pySVModel/actions/workflows/Pipeline.yml
+.. |SHIELD:png:pySVModel-gha-test| image:: https://raster.shields.io/github/workflow/status/edaa-org/pySVModel/Pipeline/main?longCache=true&style=flat-square&label=Build%20and%20Test&logo=GitHub%20Actions&logoColor=FFFFFF
    :alt: GitHub Workflow - Build and Test Status
    :height: 22
-   :target: https://GitHub.com/edaa-org/pySVModel/actions?query=workflow%3A%22Test+and+Coverage%22
+   :target: https://GitHub.com/edaa-org/pySVModel/actions/workflows/Pipeline.yml
 
 .. # Codacy - quality
 .. |SHIELD:svg:pySVModel-codacy-quality| image:: https://img.shields.io/codacy/grade/39d312bf98244961975559f141c3e000?longCache=true&style=flat-square&logo=codacy


### PR DESCRIPTION
This PR changes the Pipeline name from a large list of words to just `Pipeline`. That allows simplifying the shields. At the same time, the target of CI shields is updated to use `...actions/workflows/Pipeline.yml` instead of a query argument.