### PR TITLE
Changes due to updates pyTooling/Actions

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -119,11 +119,19 @@ jobs:
     with:
       package: ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
       remaining: |
-        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-3.6
-        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-3.7
-        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-3.8
-        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-3.9
-        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-3.10
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.7
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.8
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.9
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.10
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.7
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.8
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.9
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.10
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-msys2-3.9
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.7
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.8
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.9
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.10
         ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
         ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
         ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
 -r ../requirements.txt
 
-pyTooling>=1.7.0
+pyTooling>=1.9.2
 
 # Enforce latest version on ReadTheDocs
 sphinx>=4.3.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -9,4 +9,4 @@ pytest-cov>=3.0.0
 
 # Static Type Checking
 mypy>=0.931
-lxml>=4.6.4
+lxml>=4.6


### PR DESCRIPTION
# Changes

* Changes due to an updated version of pyTooling/Actions.
  * Lowered requirement on `lxml`.
  * Added more artifact names to the cleanup rule.
